### PR TITLE
Fix for cloudStatus out-of-bound index access

### DIFF
--- a/src/screens/WeatherDetailScreen.js
+++ b/src/screens/WeatherDetailScreen.js
@@ -46,7 +46,7 @@ export default class WeatherDetailScreen extends React.Component {
       '매우 흐림'
     ];
 
-    const text = (clouds === null) ? '정보 없음' : cloudStatus[Math.max(parseInt(clouds / 20), 4)];
+    const text = (clouds === null) ? '정보 없음' : cloudStatus[Math.min(parseInt(clouds / 20), 4)];
 
     return (
       <Text>구름: {text}</Text>


### PR DESCRIPTION
Math.max를 사용할 경우 parseInt(clouds / 20) > 4일 경우 무효한 인덱스에 접근합니다.
예를 들어, clouds = 100일 경우 cloudStatus[5]를 접근하게 되는데 이는 무효합니다.

대신 Math.min을 사용하면 최대 인덱스가 4가 되도록 설정할 수 있어 더 적합하다고 생각됩니다.